### PR TITLE
Correctly handle file paths and limit image upload size passed to WX

### DIFF
--- a/android/src/main/kotlin/com/jarvan/fluwx/utils/ShareImageUtil.java
+++ b/android/src/main/kotlin/com/jarvan/fluwx/utils/ShareImageUtil.java
@@ -25,6 +25,8 @@ import okio.Source;
 
 public class ShareImageUtil {
 
+    final static int WX_MAX_IMAGE_BYTE_SIZE = 10485760;
+
     public static byte[] getImageData(PluginRegistry.Registrar registrar, String path) {
         byte[] result = null;
         if (path.startsWith(WeChatPluginImageSchema.SCHEMA_ASSETS)) {
@@ -39,8 +41,14 @@ public class ShareImageUtil {
 
         } else if (path.startsWith(WeChatPluginImageSchema.SCHEMA_FILE)) {
             Bitmap bmp = null;
-            bmp = BitmapFactory.decodeFile(path);
-            result = Util.bmpToByteArray(bmp, true);
+            String pathWithoutUri = path.substring("file://".length());
+            bmp = BitmapFactory.decodeFile(pathWithoutUri);
+
+            if (bmp.getAllocationByteCount() >= WX_MAX_IMAGE_BYTE_SIZE) {
+                result = Util.bmpToCompressedByteArray(bmp, Bitmap.CompressFormat.JPEG, true);
+            } else {
+                result = Util.bmpToByteArray(bmp, true);
+            }
         } else {
 //            result = handleNetworkImage(registrar, path);
             result = Util.inputStreamToByte(openStream(path));

--- a/android/src/main/kotlin/com/jarvan/fluwx/utils/Util.java
+++ b/android/src/main/kotlin/com/jarvan/fluwx/utils/Util.java
@@ -27,6 +27,24 @@ class Util {
         return bmpToByteArray(bmp, CompressFormat.PNG, needRecycle);
     }
 
+    public static byte[] bmpToCompressedByteArray(final Bitmap bmp, CompressFormat format, final boolean needRecycle) {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        bmp.compress(format, 25, output);
+        if (needRecycle) {
+            bmp.recycle();
+        }
+
+        byte[] result = output.toByteArray();
+        try {
+            output.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return result;
+    }
+
+
     public static byte[] bmpToByteArray(final Bitmap bmp, CompressFormat format, final boolean needRecycle) {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         bmp.compress(format, 100, output);


### PR DESCRIPTION
Dart passes in a file:// filename, but Java expects a file path to just /be/the/pathname.
Also WeChat limits the size of the image that can be posted, so this compresses the image so that large images can be shared.