### PR TITLE
Prepare for Uint8List SDK breaking change

### DIFF
--- a/example/lib/pay_page.dart
+++ b/example/lib/pay_page.dart
@@ -42,7 +42,7 @@ class _PayPageState extends State<PayPage> {
               };
               var request = await h.getUrl(Uri.parse(_url));
               var response = await request.close();
-              var data = await response.transform(Utf8Decoder()).join();
+              var data = await Utf8Decoder().bind(response).join();
               Map<String, dynamic> result = json.decode(data);
               print(result['appid']);
               print(result["timestamp"]);


### PR DESCRIPTION
A recent change to the Dart SDK updated `HttpClientResponse`
to implement `Stream<Uint8List>` rather than implementing
`Stream<List<int>>`.

This forwards-compatible change updates calls to
`Stream.transform(StreamTransformer)` to instead call the
functionally equivalent `StreamTransformer.bind(Stream)`
API, which puts the stream in a covariant position and
thus causes the SDK change to be non-breaking.

https://github.com/dart-lang/sdk/issues/36900
