### PR TITLE
Fix 微信小程序返回APP, fixes #85

### DIFF
--- a/android/src/main/kotlin/com/jarvan/fluwx/FluwxPlugin.kt
+++ b/android/src/main/kotlin/com/jarvan/fluwx/FluwxPlugin.kt
@@ -30,6 +30,7 @@ class FluwxPlugin(private val registrar: Registrar, channel: MethodChannel) : Me
         fun registerWith(registrar: Registrar): Unit {
             val channel = MethodChannel(registrar.messenger(), "com.jarvanmo/fluwx")
             WXAPiHandler.setRegistrar(registrar)
+            FluwxRequestHandler.setRegistrar(registrar)
             FluwxResponseHandler.setMethodChannel(channel)
             channel.setMethodCallHandler(FluwxPlugin(registrar, channel))
         }

--- a/android/src/main/kotlin/com/jarvan/fluwx/handler/FluwxRequestHandler.kt
+++ b/android/src/main/kotlin/com/jarvan/fluwx/handler/FluwxRequestHandler.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2018 The OpenFlutter Organization
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jarvan.fluwx.handler
+
+import io.flutter.plugin.common.PluginRegistry
+
+object FluwxRequestHandler {
+
+    private var registrar: PluginRegistry.Registrar? = null
+
+    fun setRegistrar(reg: PluginRegistry.Registrar) {
+        registrar = reg
+    }
+
+    fun getRegistrar():PluginRegistry.Registrar?{
+        return registrar;
+    }
+
+}

--- a/android/src/main/kotlin/com/jarvan/fluwx/wxapi/FluwxWXEntryActivity.kt
+++ b/android/src/main/kotlin/com/jarvan/fluwx/wxapi/FluwxWXEntryActivity.kt
@@ -58,7 +58,14 @@ open class FluwxWXEntryActivity : Activity(), IWXAPIEventHandler {
 
 
     override fun onReq(baseReq: BaseReq) {
-
+        // FIXME: 可能是官方的Bug，从微信拉起APP的Intent类型不对，无法跳转回Flutter Activity
+        // 稳定复现场景：微信版本为7.0.5，小程序SDK为2.7.7
+        val activity = FluwxRequestHandler.getRegistrar()?.activity();
+        if (baseReq.type == 4 && activity is Activity){  
+            // com.tencent.mm.opensdk.constants.ConstantsAPI.COMMAND_SHOWMESSAGE_FROM_WX = 4
+            startActivity(Intent(this, activity::class.java))
+            finish()
+        }
     }
 
     // 第三方应用发送到微信的请求处理后的响应结果，会回调到该方法


### PR DESCRIPTION
- 问题描述：从APP分享小程序卡片到微信，再从微信[点击按钮返回APP](https://developers.weixin.qq.com/miniprogram/dev/framework/open-ability/launchApp.html)，出现白屏/黑屏
- 问题分析：正常触发**FluwxWXEntryActivity**的**onCreate**，但传入的Intent不对，一直停留在当前页面：

```kotlin
try {
            WXAPiHandler.wxApi?.handleIntent(intent, this)
        } catch (e: Exception) {
            e.printStackTrace()
            finish()
}

```

- 解决方案：注册组件时保存[Registrar](https://api.flutter.dev/javadoc/io/flutter/plugin/common/PluginRegistry.Registrar.html)对象，拿到之前的**Activity**手动跳转

- 注意事项：持续关注[官方发版动态](https://developers.weixin.qq.com/miniprogram/dev/framework/release/)，修复之后可删除这部分Hacks