### PR TITLE
wechat image share

### DIFF
--- a/android/src/main/kotlin/com/jarvan/fluwx/handlers/FluwxShareHandler.kt
+++ b/android/src/main/kotlin/com/jarvan/fluwx/handlers/FluwxShareHandler.kt
@@ -134,7 +134,7 @@ internal interface FluwxShareHandler : CoroutineScope {
                 sourceByteArray.isEmpty() -> {
                     WXImageObject()
                 }
-                sourceByteArray.size > 500 * 1024 -> {
+                else -> {
                     WXImageObject().apply {
                         if (supportFileProvider && targetHigherThanN) {
                             setImagePath(getFileContentUri(sourceByteArray.toCacheFile(context, sourceImage.suffix)))
@@ -146,9 +146,6 @@ internal interface FluwxShareHandler : CoroutineScope {
                             }
                         }
                     }
-                }
-                else -> {
-                    WXImageObject(sourceByteArray)
                 }
             }
             val msg = WXMediaMessage()


### PR DESCRIPTION
android 11分享图片失败，提示要使用FileProvider