### PR TITLE
fix #338 on Android

### DIFF
--- a/android/src/main/kotlin/com/jarvan/fluwx/handlers/FluwxRequestHandler.kt
+++ b/android/src/main/kotlin/com/jarvan/fluwx/handlers/FluwxRequestHandler.kt
@@ -21,6 +21,7 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
 import android.util.Log
+import com.jarvan.fluwx.FluwxPlugin
 import com.tencent.mm.opensdk.modelmsg.ShowMessageFromWX
 import io.flutter.plugin.common.MethodChannel
 import com.tencent.mm.opensdk.modelbase.BaseReq
@@ -30,13 +31,6 @@ object FluwxRequestHandler {
     private const val KEY_FLUWX_REQUEST_INFO_BUNDLE = "KEY_FLUWX_REQUEST_INFO_BUNDLE"
 
     var customOnReqDelegate: ((baseReq: BaseReq, activity: Activity) -> Unit)? = null
-
-    private var channel: MethodChannel? = null
-
-    fun setMethodChannel(channel: MethodChannel) {
-        FluwxRequestHandler.channel = channel
-    }
-
 
     fun handleRequestInfoFromIntent(intent: Intent) {
         intent.getBundleExtra(KEY_FLUWX_REQUEST_INFO_BUNDLE)?.run {
@@ -59,7 +53,7 @@ object FluwxRequestHandler {
         val result = mapOf(
                 "extMsg" to req.message.messageExt,
         )
-        channel?.invokeMethod("onWXShowMessageFromWX", result)
+        FluwxPlugin.callingChannel?.invokeMethod("onWXShowMessageFromWX", result)
     }
 
     private fun defaultOnReqDelegate(baseReq: BaseReq, activity: Activity) {

--- a/android/src/main/kotlin/com/jarvan/fluwx/handlers/FluwxResponseHandler.kt
+++ b/android/src/main/kotlin/com/jarvan/fluwx/handlers/FluwxResponseHandler.kt
@@ -15,6 +15,7 @@
  */
 package com.jarvan.fluwx.handlers
 
+import com.jarvan.fluwx.FluwxPlugin
 import com.tencent.mm.opensdk.modelbase.BaseResp
 import com.tencent.mm.opensdk.modelbiz.SubscribeMessage
 import com.tencent.mm.opensdk.modelbiz.WXLaunchMiniProgram
@@ -25,16 +26,11 @@ import com.tencent.mm.opensdk.modelpay.PayResp
 import io.flutter.plugin.common.MethodChannel
 
 object FluwxResponseHandler {
-    private var channel: MethodChannel? = null
 
     private const val errStr = "errStr"
     private const val errCode = "errCode"
     private const val openId = "openId"
     private const val type = "type"
-
-    fun setMethodChannel(channel: MethodChannel) {
-        FluwxResponseHandler.channel = channel
-    }
 
     fun handleResponse(response: BaseResp) {
         when (response) {
@@ -56,7 +52,7 @@ object FluwxResponseHandler {
                 "scene" to response.scene,
                 type to response.type)
 
-        channel?.invokeMethod("onSubscribeMsgResp", result)
+        FluwxPlugin.callingChannel?.invokeMethod("onSubscribeMsgResp", result)
     }
 
     private fun handleLaunchMiniProgramResponse(response: WXLaunchMiniProgram.Resp) {
@@ -71,7 +67,7 @@ object FluwxResponseHandler {
             result["extMsg"] = response.extMsg
         }
 
-        channel?.invokeMethod("onLaunchMiniProgramResponse", result)
+        FluwxPlugin.callingChannel?.invokeMethod("onLaunchMiniProgramResponse", result)
     }
 
     private fun handlePayResp(response: PayResp) {
@@ -83,7 +79,7 @@ object FluwxResponseHandler {
                 type to response.type,
                 errCode to response.errCode
         )
-        channel?.invokeMethod("onPayResponse", result)
+        FluwxPlugin.callingChannel?.invokeMethod("onPayResponse", result)
     }
 
     private fun handleSendMessageResp(response: SendMessageToWX.Resp) {
@@ -93,7 +89,7 @@ object FluwxResponseHandler {
                 errCode to response.errCode,
                 openId to response.openId)
 
-        channel?.invokeMethod("onShareResponse", result)
+        FluwxPlugin.callingChannel?.invokeMethod("onShareResponse", result)
     }
 
     private fun handleAuthResponse(response: SendAuth.Resp) {
@@ -108,7 +104,7 @@ object FluwxResponseHandler {
                 "url" to response.url,
                 type to response.type)
 
-        channel?.invokeMethod("onAuthResponse", result)
+        FluwxPlugin.callingChannel?.invokeMethod("onAuthResponse", result)
     }
 
 
@@ -121,6 +117,6 @@ object FluwxResponseHandler {
                 openId to response.openId,
                 type to response.type)
 
-        channel?.invokeMethod("onWXOpenBusinessWebviewResponse", result)
+        FluwxPlugin.callingChannel?.invokeMethod("onWXOpenBusinessWebviewResponse", result)
     }
 }


### PR DESCRIPTION
Android端有 #338 类似的问题。
Fluwx和某些库一起使用时，FluwxPlugin会被多次调用，生成了多个channel，导致回调失败。

`W/FlutterJNI(12866): Tried to send a platform message to Flutter, but FlutterJNI was detached from native C++. Could not send. Channel: com.jarvanmo/fluwx. Response ID: 0`

提交的解决办法，是在FluwxPlugin中维持一个全局唯一的静态MethodChannel，当每个FluwxPlugin被调用onMethodCall方法时，会修改全局MethodChannel，后续的结果回调会通过这个全局MethodChannel来执行，从而保证来自不同Channel的Request可以收到对应的Response。