### PR TITLE
分享小程序，data数据压缩成功，但是image转data 导致图片大小变大

### DIFF
--- a/ios/Classes/FluwxShareHandler.m
+++ b/ios/Classes/FluwxShareHandler.m
@@ -235,16 +235,15 @@ NSObject <FlutterPluginRegistrar> *_fluwxRegistrar;
         NSDictionary *hdImagePath = call.arguments[@"hdImagePath"];
         if (hdImagePath != (id) [NSNull null]) {
             NSData *imageData = [self getNsDataFromWeChatFile:hdImagePath];
-            NSString *suffix = hdImagePath[@"suffix"];
-            BOOL isPNG = [self isPNG:suffix];
             BOOL compress = call.arguments[fluwxKeyCompressThumbnail];
 
-            UIImage *uiImage = [self getThumbnailFromNSData:imageData size:120 * 1024 isPNG:isPNG compress:compress];
-            if (isPNG) {
-                hdImageData = UIImagePNGRepresentation(uiImage);
-            } else {
-                hdImageData = UIImageJPEGRepresentation(uiImage, 1);
-            }
+            hdImageData = [self getThumbnailDataFromNSData:imageData size:120 * 1024 compress:compress];
+//            UIImage *uiImage = [self getThumbnailFromNSData:imageData size:120 * 1024 isPNG:isPNG compress:compress];
+//            if (isPNG) {
+//                hdImageData = UIImagePNGRepresentation(uiImage);
+//            } else {
+//                hdImageData = UIImageJPEGRepresentation(uiImage, 1);
+//            }
         }
 
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -330,6 +329,14 @@ NSObject <FlutterPluginRegistrar> *_fluwxRegistrar;
     return [ThumbnailHelper compressImage:uiImage toByte:size isPNG:isPNG];
     else
         return uiImage;
+}
+
+- (NSData *)getThumbnailDataFromNSData:(NSData *)data size:(NSUInteger)size compress:(BOOL)compress {
+    if(compress) {
+        return [ThumbnailHelper compressImageData:data toByte:size];
+    } else{
+        return data;
+    }
 }
 
 - (NSString *)readFileFromAssets:(NSString *)imagePath {

--- a/ios/Classes/ThumbnailHelper.h
+++ b/ios/Classes/ThumbnailHelper.h
@@ -7,4 +7,10 @@
 
 @interface ThumbnailHelper : NSObject
 + (UIImage *)compressImage:(UIImage *)image toByte:(NSUInteger)maxLength isPNG:(BOOL)isPNG;
+
+
+/// NSData 压缩后转NSData
+/// @param imageData 来源data
+/// @param maxLength 压缩目标值，压缩结果在maxLength的0.9~1之间
++ (NSData *)compressImageData:(NSData *)imageData toByte:(NSUInteger)maxLength;
 @end


### PR DESCRIPTION
平台：iOS
api：分享小程序
问题：分享小程序，data数据压缩成功；但是uiimage转nsdata的方法会导致图片大小变大，结果微信提示图片过大
解决方案：压缩成功后的图片，不在转换成UIImage;同时在压缩方法的类里增加一个方法
