### PR TITLE
修改iOS支付时传入参数extData，支付完成回调无法获取到

### DIFF
--- a/ios/Classes/FluwxPlugin.m
+++ b/ios/Classes/FluwxPlugin.m
@@ -203,6 +203,7 @@ FlutterMethodChannel *channel = nil;
     NSString *nonceStr = call.arguments[@"nonceStr"];
     UInt32 timeStamp = [timestamp unsignedIntValue];
     NSString *sign = call.arguments[@"sign"];
+    [FluwxDelegate defaultManager].extData = call.arguments[@"extData"];
     [WXApiRequestHandler sendPayment:call.arguments[@"appId"]
                            PartnerId:partnerId
                             PrepayId:prepayId

--- a/ios/Classes/FluwxResponseHandler.m
+++ b/ios/Classes/FluwxResponseHandler.m
@@ -6,6 +6,7 @@
 #import "FluwxStringUtil.h"
 #import "WXApiObject.h"
 #import "FluwxResponseHandler.h"
+#import "FluwxDelegate.h"
 
 @implementation FluwxResponseHandler
 
@@ -213,8 +214,10 @@ FlutterMethodChannel *fluwxMethodChannel = nil;
                 errStr: [FluwxStringUtil nilToEmpty:resp.errStr],
                 errCode: @(payResp.errCode),
                 type: @(payResp.type),
+                @"extData": [FluwxDelegate defaultManager].extData,
                 @"returnKey": payResp.returnKey == nil ? @"" : payResp.returnKey,
         };
+        [FluwxDelegate defaultManager].extData = nil;
         [fluwxMethodChannel invokeMethod:@"onPayResponse" arguments:result];
     } else if ([resp isKindOfClass:[WXOpenBusinessWebViewResp class]]) {
         WXOpenBusinessWebViewResp *businessResp = (WXOpenBusinessWebViewResp *) resp;

--- a/ios/Classes/public/FluwxDelegate.h
+++ b/ios/Classes/public/FluwxDelegate.h
@@ -10,6 +10,8 @@
 
 @property (strong,nonatomic)NSString *extMsg;
 
+@property (strong,nonatomic)NSString *extData;
+
 + (instancetype)defaultManager;
 
 - (void)registerWxAPI:(NSString *)appId universalLink:(NSString *)universalLink;


### PR DESCRIPTION
修改iOS支付时，支付完成回调无法获取传入的extData参数