### PR TITLE
Update ImagesIO.kt

### DIFF
--- a/android/src/main/kotlin/com/jarvan/fluwx/io/ImagesIO.kt
+++ b/android/src/main/kotlin/com/jarvan/fluwx/io/ImagesIO.kt
@@ -85,7 +85,7 @@ class ImagesIOIml(override val image: WeChatFile) : ImagesIO {
                 result.recycle()
             }
             result = tmp
-            if (result.byteCount < maxLength) {
+            if (result.byteCount <= maxLength) {
                 break
             }
         }


### PR DESCRIPTION
fix 当result.byteCount与maxLength相等时的死循环问题。