### PR TITLE
Improve `fluwx` definition under the pubspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ dependencies:
 
 ## Configurations
 
-`Fluwx` enables multiple configurations in the section `fluwx` of `pubspec.yaml` from v4, you can reference [pubspec.yaml](./example/pubspec.yaml#L86)
+`Fluwx` enables multiple configurations in the section `fluwx` of `pubspec.yaml` from v4, you can reference [pubspec.yaml](./example/pubspec.yaml#L10)
 for more details.
 
 > For iOS, some configurations, such as url_scheme，universal_link, LSApplicationQueriesSchemes, can be configured by `fluwx`,

--- a/README_CN.md
+++ b/README_CN.md
@@ -56,7 +56,7 @@ dependencies:
 
 ## 配置
 
-`Fluwx` 从v4开始可以在`pubspec.yaml`的`fluwx`进行一些配置。具体可以参考[pubspec.yaml](./example/pubspec.yaml)。
+`Fluwx` 从v4开始可以在`pubspec.yaml`的`fluwx`进行一些配置。具体可以参考[pubspec.yaml](./example/pubspec.yaml#L10)。
 
 > V4开始，iOS中的url_scheme，universal_link, LSApplicationQueriesSchemes可以不必开发者手动配动。只需在`pubspec.yaml`
 > 中填写即可。

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -7,6 +7,17 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 environment:
   sdk: '>=3.0.0 <4.0.0'
 
+fluwx:
+  app_id: '123456'
+  debug_logging: true # Logging in debug mode.
+  android:
+#    interrupt_wx_request: true # Defaults to true.
+#    flutter_activity: 'MainActivity' # Defaults to app's launcher
+  ios:
+    universal_link: https://testdomain.com
+#    scene_delegate: true # Defaults to false.
+#    no_pay: false # Set to false to disable payment.
+
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
 # consider running `flutter pub upgrade --major-versions`. Alternatively,
@@ -83,15 +94,3 @@ flutter:
   # For details regarding fonts from package dependencies,
   # see https://flutter.dev/custom-fonts/#from-packages
 
-fluwx:
-  app_id: 123456
-  # only debug in debug mode
-  debug_logging: true
-  android:
-#      interrupt_wx_request: true # default is true
-#      flutter_activity: MainActivity #Default to launch app's launcher
-  ios:
-    universal_link: https://testdomain.com
-#    scene_delegate: true #default false
-  # payment is enabled by default
-#    no_pay: true


### PR DESCRIPTION
Leaving the `fluwx` defined at to bottom usually causes users confused when they misconfigure the indents:

Wrong:
```yaml
flutter:
  fluwx:
```

Correct:
```yaml
flutter:
fluwx:
```

The PR sort the `fluwx` section before dependencies to provide better readability.