### PR TITLE
fix + docs: fix #568, #555 & update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Buy the writer a cup of coffee。
 ![subscribe](https://gitee.com/OpenFlutter/resoures-repository/raw/master/fluwx/wx_subscription.png)
 
 
-## Start history
+## Star history
 
 ![stars](https://starchart.cc/OpenFlutter/fluwx.svg)
 

--- a/doc/LAUNCH_APP_FROM_H5.md
+++ b/doc/LAUNCH_APP_FROM_H5.md
@@ -8,18 +8,6 @@
 - The event type of **Launch-App-From-H5** on Android is `WeChatShowMessageFromWXRequest`
 - The event type of **Launch-App-From-H5** on IOS is `WeChatLaunchFromWXRequest`
 
-> ### iOS specific configuration
-
-Please register your WXApi in your `AppDelegate`:
-
-```oc
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    //向微信注册
-[[FluwxDelegate defaultManager] registerWxAPI:@"" universalLink:@""];
-    return YES;
-}
-```
-
 ## Example
 
 ```dart

--- a/doc/LAUNCH_APP_FROM_H5.md
+++ b/doc/LAUNCH_APP_FROM_H5.md
@@ -1,6 +1,17 @@
+## WeChat reference document
 
-## IOS
+- [WeChat open label jumps to APP: &lt;wx-open-launch-app&gt;](https://developers.weixin.qq.com/doc/offiaccount/OA_Web_Apps/Wechat_Open_Tag.html#%E8%B7%B3%E8%BD%ACAPP%EF%BC%9Awx-open-launch-app)
+- [App gets the extinfo data in the open tag <wx-open-launch-app>](https://developers.weixin.qq.com/doc/offiaccount/OA_Web_Apps/APP_GET_EXTINF.html)
+
+## Platform differences
+
+- The event type of **Launch-App-From-H5** on Android is `WeChatShowMessageFromWXRequest`
+- The event type of **Launch-App-From-H5** on IOS is `WeChatLaunchFromWXRequest`
+
+> ### iOS specific configuration
+
 Please register your WXApi in your `AppDelegate`:
+
 ```oc
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     //向微信注册
@@ -9,4 +20,30 @@ Please register your WXApi in your `AppDelegate`:
 }
 ```
 
-> If you want to get ext from website, please call ``fluwx.getExtMsg()`。`For details, please read the example.
+## Example
+
+```dart
+void handle_launch_from_h5() {
+  Fluwx fluwx = Fluwx();
+
+  fluwx.addSubscriber((response) {
+    // 1. Handle responses separately for android and ios
+    if (response is WeChatShowMessageFromWXRequest) {
+      debugPrint("launch-app-from-h5 on android");
+      // do something here only for android after launch from wechat
+    } else if (response is WeChatLaunchFromWXRequest) {
+      debugPrint("launch-app-from-h5 on ios");
+      // do something here only for android after launch from wechat
+    }
+
+    // 2. Or handling responses together for android and ios
+    if (response is WeChatLaunchFromWXRequest ||
+        response is WeChatShowMessageFromWXRequest) {
+      debugPrint("launch-app-from-h5");
+      // do something here for both android and ios after launch from wechat
+    }
+  });
+}
+```
+
+> If you want to get ext from website, please call `fluwx.getExtMsg()`。For details, please read the example project.

--- a/doc/LAUNCH_APP_FROM_H5_CN.md
+++ b/doc/LAUNCH_APP_FROM_H5_CN.md
@@ -8,18 +8,6 @@
 - 安卓端 **微信唤起App** 的事件类型为 `WeChatShowMessageFromWXRequest`
 - IOS端 **微信唤起App** 的事件类型为 `WeChatLaunchFromWXRequest`
 
-> ### iOS 特定配置
-
-请在你的`AppDelegate`中主动注册`WXApi`
-
-```oc
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    //向微信注册
-[[FluwxDelegate defaultManager] registerWxAPI:@"" universalLink:@""];
-    return YES;
-}
-```
-
 ## 示例
 
 ```dart

--- a/doc/LAUNCH_APP_FROM_H5_CN.md
+++ b/doc/LAUNCH_APP_FROM_H5_CN.md
@@ -1,6 +1,17 @@
+## 微信参考文档
 
-## IOS
+- [微信开放标签 &lt;wx-open-launch-app&gt; 跳转App](https://developers.weixin.qq.com/doc/offiaccount/OA_Web_Apps/Wechat_Open_Tag.html#%E8%B7%B3%E8%BD%ACAPP%EF%BC%9Awx-open-launch-app)
+- [App获取开放标签 &lt;wx-open-launch-app&gt; 中的 extinfo 数据](https://developers.weixin.qq.com/doc/offiaccount/OA_Web_Apps/APP_GET_EXTINF.html)
+
+## 平台差异
+
+- 安卓端 **微信唤起App** 的事件类型为 `WeChatShowMessageFromWXRequest`
+- IOS端 **微信唤起App** 的事件类型为 `WeChatLaunchFromWXRequest`
+
+> ### iOS 特定配置
+
 请在你的`AppDelegate`中主动注册`WXApi`
+
 ```oc
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     //向微信注册
@@ -9,5 +20,30 @@
 }
 ```
 
-> 如你想主动获取从网页传进来的值 ，请主动调用`fluwx.getExtMsg()`。更多信息请参考example.
+## 示例
 
+```dart
+void handle_launch_from_h5() {
+  Fluwx fluwx = Fluwx();
+
+  fluwx.addSubscriber((response) {
+    // 1. 为安卓和ios分开处理响应
+    if (response is WeChatShowMessageFromWXRequest) {
+      debugPrint("launch-app-from-h5 on android");
+      // 从微信启动后，在这里只为 android 做一些事情
+    } else if (response is WeChatLaunchFromWXRequest) {
+      debugPrint("launch-app-from-h5 on ios");
+      // 从微信启动后，在这里只为 ios 做一些事情
+    }
+
+    // 2. 或者为安卓和ios一起处理响应
+    if (response is WeChatLaunchFromWXRequest ||
+        response is WeChatShowMessageFromWXRequest) {
+      debugPrint("launch-app-from-h5");
+      // 从微信启动后，在这里为 android 和 ios 做一些事情
+    }
+  });
+}
+```
+
+> 如你想主动获取从网页传进来的值 ，请主动调用`fluwx.getExtMsg()`。更多信息请参考example项目.

--- a/ios/Classes/FluwxPlugin.m
+++ b/ios/Classes/FluwxPlugin.m
@@ -421,9 +421,12 @@ NSObject <FlutterPluginRegistrar> *_fluwxRegistrar;
         return [WXApi handleOpenURL:url delegate:self];
     }else {
         // unregistered -- cache open url request and handle it once WXApi is registered
+        __weak typeof(self) weakSelf = self;
         _cachedOpenUrlRequest = ^() {
-            [WXApi handleOpenURL:url delegate:self];
+          __strong typeof(weakSelf) strongSelf = weakSelf;
+          [WXApi handleOpenURL:url delegate:strongSelf];
         };
+
 
         // simply return YES to indicate that we can handle open url request later
         return YES;

--- a/ios/Classes/FluwxPlugin.m
+++ b/ios/Classes/FluwxPlugin.m
@@ -1016,7 +1016,7 @@ NSObject <FlutterPluginRegistrar> *_fluwxRegistrar;
     if ([req isKindOfClass:[GetMessageFromWXReq class]]) {
 
     } else if ([req isKindOfClass:[ShowMessageFromWXReq class]]) {
-//onWXLaunchFromWX
+        // ShowMessageFromWXReq -- android spec
         ShowMessageFromWXReq *showMessageFromWXReq = (ShowMessageFromWXReq *) req;
         WXMediaMessage *wmm = showMessageFromWXReq.message;
 
@@ -1026,6 +1026,7 @@ NSObject <FlutterPluginRegistrar> *_fluwxRegistrar;
         [result setValue:showMessageFromWXReq.lang forKey:@"lang"];
         [result setValue:showMessageFromWXReq.country forKey:@"country"];
 
+        // Cache extMsg for later use (by calling 'getExtMsg')
         [FluwxDelegate defaultManager].extMsg= wmm.messageExt;
 
         if (_isRunning) {
@@ -1039,6 +1040,7 @@ NSObject <FlutterPluginRegistrar> *_fluwxRegistrar;
         }
 
     } else if ([req isKindOfClass:[LaunchFromWXReq class]]) {
+        // ShowMessageFromWXReq -- ios spec
         LaunchFromWXReq *launchFromWXReq = (LaunchFromWXReq *) req;
         WXMediaMessage *wmm = launchFromWXReq.message;
 
@@ -1048,6 +1050,8 @@ NSObject <FlutterPluginRegistrar> *_fluwxRegistrar;
         [result setValue:launchFromWXReq.lang forKey:@"lang"];
         [result setValue:launchFromWXReq.country forKey:@"country"];
 
+        // Cache extMsg for later use (by calling 'getExtMsg')
+        [FluwxDelegate defaultManager].extMsg= wmm.messageExt;
 
         if (_isRunning) {
             [_channel invokeMethod:@"onWXLaunchFromWX" arguments:result];
@@ -1058,8 +1062,6 @@ NSObject <FlutterPluginRegistrar> *_fluwxRegistrar;
                 [strongSelf->_channel invokeMethod:@"onWXLaunchFromWX" arguments:result];
             };
         }
-
-
     }
 
 }


### PR DESCRIPTION
- update doc for section [Launch App From H5](https://github.com/OpenFlutter/fluwx/blob/master/doc/LAUNCH_APP_FROM_H5.md)
- cache open url request when WXApi is not registered, and handle it once WXApi is registered (fix [#555](https://github.com/OpenFlutter/fluwx/issues/555) and [#568](https://github.com/OpenFlutter/fluwx/issues/568))

---

主要解决了 iOS 端的冷启动参数传递问题，不再需要在原生代码的 `AppDelegate` 中初始化 `WXApi`，对冷启动参数的处理双端保持一致

经过简单测试，`addSubscriber` 和 `getExtMsg` 都正常可用