### PR TITLE
feat: add ios ignore_security

### DIFF
--- a/ios/fluwx.podspec
+++ b/ios/fluwx.podspec
@@ -58,13 +58,18 @@ if cfg['fluwx'] && cfg['fluwx']['app_id']
     app_id = cfg['fluwx']['app_id']
 end
 
+ignore_security = ''
+if cfg['fluwx'] && cfg['fluwx']['ios'] && cfg['fluwx']['ios']['ignore_security'] == true
+    ignore_security = '-i'
+end
+Pod::UI.puts "ignore_security: #{ignore_security}"
 
 if cfg['fluwx'] && (cfg['fluwx']['ios']  && cfg['fluwx']['ios']['universal_link'])
     universal_link = cfg['fluwx']['ios']['universal_link']
     if app_id.nil?
-        system("ruby #{current_dir}/wechat_setup.rb -u #{universal_link} -p #{project_dir} -n Runner.xcodeproj")
+        system("ruby #{current_dir}/wechat_setup.rb #{ignore_security} -u #{universal_link} -p #{project_dir} -n Runner.xcodeproj")
     else
-        system("ruby #{current_dir}/wechat_setup.rb -a #{app_id} -u #{universal_link} -p #{project_dir} -n Runner.xcodeproj")
+        system("ruby #{current_dir}/wechat_setup.rb #{ignore_security} -a #{app_id} -u #{universal_link} -p #{project_dir} -n Runner.xcodeproj")
     end
 else
     abort("required values:[universal_link] are missing. Please add them in pubspec.yaml:\nfluwx:\n \nios:\nuniversal_link: https://${applinks domain}/universal_link/${example_app}/wechat/\n")

--- a/ios/wechat_setup.rb
+++ b/ios/wechat_setup.rb
@@ -24,6 +24,10 @@ OptionParser.new do |options|
         options_dict[:project_name] = name
     end
 
+    options.on("-i", "--ignoreSecurity", "Ignore modifying NSAppTransportSecurity") do |opts|
+        options_dict[:ignore_security] = true
+    end
+
     options.on("-a", "--appId=APPID", String, "App ID for Wechat") do |opts|
         options_dict[:app_id] = opts
     end
@@ -103,18 +107,20 @@ project.targets.each do |target|
                 end
                 File.write(infoplistFile, Plist::Emit.dump(result))
             end
-            security = result["NSAppTransportSecurity"]
-            if !security
-                security = {}
-                result["NSAppTransportSecurity"] = security
-            end
-            if security["NSAllowsArbitraryLoads"] != true
-                security["NSAllowsArbitraryLoads"] = true
-                File.write(infoplistFile, Plist::Emit.dump(result))
-            end
-            if security["NSAllowsArbitraryLoadsInWebContent"] != true
-                security["NSAllowsArbitraryLoadsInWebContent"] = true
-                File.write(infoplistFile, Plist::Emit.dump(result))
+            if !options_dict[:ignore_security]
+                security = result["NSAppTransportSecurity"]
+                if !security
+                    security = {}
+                    result["NSAppTransportSecurity"] = security
+                end
+                if security["NSAllowsArbitraryLoads"] != true
+                    security["NSAllowsArbitraryLoads"] = true
+                    File.write(infoplistFile, Plist::Emit.dump(result))
+                end
+                if security["NSAllowsArbitraryLoadsInWebContent"] != true
+                    security["NSAllowsArbitraryLoadsInWebContent"] = true
+                    File.write(infoplistFile, Plist::Emit.dump(result))
+                end
             end
         end
         sectionObject.build_configurations.each do |config|


### PR DESCRIPTION
每次运行插件会自动修改 iOS 的 info.plist 中

```
<key>NSAppTransportSecurity</key>
<dict>
<key>NSAllowsArbitraryLoads</key>
<true/>
<key>NSAllowsArbitraryLoadsInWebContent</key>
<true/>
</dict>
```

新增 `ignore_security` 禁用这个特性:

```
fluwx:
  ios:
    ignore_security: true
```