### PR TITLE
add param yamlDir

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -66,7 +66,8 @@ android {
 }
 
 Map loadPubspec() {
-    def path = rootProject.projectDir.parent + File.separator + "pubspec.yaml"
+    def yamlDir = rootProject.hasProperty('yamlDir') ? rootProject.ext.yamlDir : ''
+    def path = rootProject.projectDir.parent + File.separator +yamlDir +"pubspec.yaml"
     InputStream input = new FileInputStream(new File(path))
     Yaml yaml = new Yaml()
     Map projectConfig = yaml.load(input)


### PR DESCRIPTION
针对混编项目可以在Android原生项目gradle.properties里配置自定义参数yamlDir来指定flutter模块的目录