### PR TITLE
Compatible with AGP-8.0+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,6 +32,15 @@ android {
     namespace "com.jarvan.fluwx"
     compileSdk 31
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     sourceSets {
         main.java.srcDirs += ['src/main/kotlin', "${buildDir}/generated/src/kotlin"]
         test.java.srcDirs += 'src/test/kotlin'

--- a/android/src/main/kotlin/com/jarvan/fluwx/handlers/WXAPiHandler.kt
+++ b/android/src/main/kotlin/com/jarvan/fluwx/handlers/WXAPiHandler.kt
@@ -21,7 +21,6 @@ package com.jarvan.fluwx.handlers
 import android.content.Context
 import android.content.pm.PackageManager
 import android.util.Log
-import com.jarvan.fluwx.BuildConfig
 import com.jarvan.fluwx.FluwxPlugin
 import com.tencent.mm.opensdk.constants.Build
 import com.tencent.mm.opensdk.openapi.IWXAPI


### PR DESCRIPTION
你好，我在升级到 Flutter 3.19.0 时，根据最新的文档

https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply

升级了 gradle 版本为 gradle-8.2-bin.zip，相关的配置文件，片段如下

settings.gradle
```
pluginManagement {
    def flutterSdkPath = {
        def properties = new Properties()
        file("local.properties").withInputStream { properties.load(it) }
        def flutterSdkPath = properties.getProperty("flutter.sdk")
        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
        return flutterSdkPath
    }
    settings.ext.flutterSdkPath = flutterSdkPath()

    includeBuild("${settings.ext.flutterSdkPath}/packages/flutter_tools/gradle")

    repositories {
        google()
        mavenCentral()
        gradlePluginPortal()
    }
}

plugins {
    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
    id "com.android.application" version "8.2.2" apply false
    id "org.jetbrains.kotlin.android" version "1.9.22" apply false
}

include ":app"
```

build.gradle
```
...
android {
    namespace 'xxx.xxx.xxx'

    compileOptions {
        sourceCompatibility JavaVersion.VERSION_17
        targetCompatibility JavaVersion.VERSION_17
    }

    kotlinOptions {
        tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
            kotlinOptions.jvmTarget = "17"
        }
    }

    sourceSets {
        main.java.srcDirs += 'src/main/kotlin'
    }
}
...
```

结果 fluwx 无法编译成功，出现了两个问题：

1. 没有强制指定 JDK 编译版本，会出现如下错误
```
Inconsistent JVM-target compatibility detected for tasks 'compileDebugJavaWithJavac' (1.8) and 'compileDebugKotlin' (17).

# 添加如下配置后解决

compileOptions {
    sourceCompatibility JavaVersion.VERSION_1_8
    targetCompatibility JavaVersion.VERSION_1_8
}

kotlinOptions {
    jvmTarget = '1.8'
}
```

2. 文件 com.jarvan.fluwx.handlers.WXAPiHandler 有一个貌似无效的引用会报错
```
import com.jarvan.fluwx.BuildConfig
```

去掉以后正常，暂时不知道是否有影响



