### PR TITLE
🐛 Construct listener gracefully

### DIFF
--- a/lib/src/fluwx.dart
+++ b/lib/src/fluwx.dart
@@ -25,20 +25,21 @@ import 'method_channel/fluwx_platform_interface.dart';
 import 'response/wechat_response.dart';
 
 class Fluwx {
-  late final WeakReference<void Function(WeChatResponse event)>
-      responseListener;
-
-  final List<WeChatResponseSubscriber> _responseListeners = [];
-
   Fluwx() {
-    responseListener = WeakReference((event) {
-      for (var listener in _responseListeners) {
-        listener(event);
-      }
-    });
-    final target = responseListener.target;
-    if (target != null) {
-      FluwxPlatform.instance.responseEventHandler.listen(target);
+    _responseSubscription = FluwxPlatform.instance.responseEventHandler.listen(
+      _responseEventListener,
+      onDone: () {
+        _responseSubscription?.cancel();
+      },
+    );
+  }
+
+  final _responseListeners = <WeChatResponseSubscriber>[];
+  StreamSubscription? _responseSubscription;
+
+  void _responseEventListener(WeChatResponse event) {
+    for (final listener in _responseListeners.toList()) {
+      listener(event);
     }
   }
 

--- a/lib/src/fluwx.dart
+++ b/lib/src/fluwx.dart
@@ -129,17 +129,17 @@ class Fluwx {
 
   /// Unsubscribe responses from WeChat
   @Deprecated("use [removeSubscriber] instead")
-  unsubscribeResponse(WeChatResponseSubscriber listener) {
+  void unsubscribeResponse(WeChatResponseSubscriber listener) {
     removeSubscriber(listener);
   }
 
   /// remove your subscriber from WeChat
-  removeSubscriber(WeChatResponseSubscriber listener) {
+  void removeSubscriber(WeChatResponseSubscriber listener) {
     _responseListeners.remove(listener);
   }
 
   /// remove all existing
-  clearSubscribers() {
+  void clearSubscribers() {
     _responseListeners.clear();
   }
 }

--- a/lib/src/foundation/cancelable.dart
+++ b/lib/src/foundation/cancelable.dart
@@ -17,20 +17,19 @@
  * the License.
  */
 
-import '../response/wechat_response.dart';
+import 'package:flutter/foundation.dart';
 
-typedef WeChatResponseSubscriber = Function(WeChatResponse response);
 mixin FluwxCancelable {
-  cancel();
+  void cancel();
 }
 
 class FluwxCancelableImpl implements FluwxCancelable {
-  final Function onCancel;
+  const FluwxCancelableImpl({required this.onCancel});
 
-  FluwxCancelableImpl({required this.onCancel});
+  final VoidCallback onCancel;
 
   @override
-  cancel() {
+  void cancel() {
     onCancel();
   }
 }

--- a/lib/src/response/wechat_response.dart
+++ b/lib/src/response/wechat_response.dart
@@ -22,6 +22,7 @@ import 'dart:typed_data';
 const String _errCode = 'errCode';
 const String _errStr = 'errStr';
 
+typedef WeChatResponseSubscriber = void Function(WeChatResponse response);
 typedef _WeChatResponseInvoker = WeChatResponse Function(Map argument);
 
 Map<String, _WeChatResponseInvoker> _nameAndResponseMapper = {


### PR DESCRIPTION
This probably fixes the concurrent modification of the listeners' list.