### PR TITLE
Improve Cocoapods related scripts

### DIFF
--- a/ios/fluwx.podspec
+++ b/ios/fluwx.podspec
@@ -21,7 +21,7 @@ end
 
 flutter_project_dir = calling_dir.slice(0..(symlinks_index))
 
-puts Psych::VERSION
+Pod::UI.puts "[fluwx] #{Psych::VERSION}"
 psych_version_gte_500 = Gem::Version.new(Psych::VERSION) >= Gem::Version.new('5.0.0')
 if psych_version_gte_500 == true
     cfg = YAML.load_file(File.join(flutter_project_dir, 'pubspec.yaml'), aliases: true)
@@ -50,25 +50,32 @@ if cfg['fluwx'] && cfg['fluwx']['ios'] && cfg['fluwx']['ios']['no_pay'] == true
 else
     fluwx_subspec = 'pay'
 end
-Pod::UI.puts "using sdk with #{fluwx_subspec}"
+Pod::UI.puts "[fluwx] Using SDK with #{fluwx_subspec}"
 
 app_id = ''
-
 if cfg['fluwx'] && cfg['fluwx']['app_id']
     app_id = cfg['fluwx']['app_id']
+end
+if !app_id.nil? && !app_id.empty?
+    Pod::UI.puts "[fluwx] app_id: #{app_id}"
 end
 
 ignore_security = ''
 if cfg['fluwx'] && cfg['fluwx']['ios'] && cfg['fluwx']['ios']['ignore_security'] == true
     ignore_security = '-i'
 end
-Pod::UI.puts "ignore_security: #{ignore_security}"
+if !ignore_security.nil? && !ignore_security.empty?
+    Pod::UI.puts "[fluwx] ignore_security: #{ignore_security}"
+end
+
 universal_link = ''
 if cfg['fluwx'] && (cfg['fluwx']['ios']  && cfg['fluwx']['ios']['universal_link'])
     universal_link = cfg['fluwx']['ios']['universal_link']
 end
+if !universal_link.nil? && !universal_link.empty?
+    Pod::UI.puts "[fluwx] universal_link: #{universal_link}"
+end
 
-Pod::UI.puts "app_id: #{app_id} universal_link: #{universal_link}"
 system("ruby #{current_dir}/wechat_setup.rb #{ignore_security} -a #{app_id} -u #{universal_link} -p #{project_dir} -n Runner.xcodeproj")
 
 Pod::Spec.new do |s|

--- a/ios/wechat_setup.rb
+++ b/ios/wechat_setup.rb
@@ -55,10 +55,14 @@ project.targets.each do |target|
     if target.name == "Runner"
         app_id = options_dict[:app_id]
         universal_link = options_dict[:universal_link]
-        applinks = ''
 
-        if (!app_id.nil? && !app_id.empty?)
-           applinks = "applinks:#{URI.parse(universal_link).host}"
+        applinks = ''
+        if (!app_id.nil? && !app_id.empty? && !universal_link.nil? && !universal_link.empty?)
+            begin
+                applinks = "applinks:#{URI.parse(universal_link).host}"
+            rescue URI::InvalidURIError
+                applinks = nil
+            end
         end
 
         sectionObject = {}


### PR DESCRIPTION
Before:

```console
Analyzing dependencies
5.1.2
using sdk with no_pay
ignore_security: 
app_id:  universal_link: 
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/uri/rfc3986_parser.rb:18:in `rescue in split': bad URI(is not URI?): nil (URI::InvalidURIError)
        from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/uri/rfc3986_parser.rb:15:in `split'
        from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/uri/rfc3986_parser.rb:73:in `parse'
        from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/uri/common.rb:234:in `parse'
        from /Users/alex/dev/garages/flutter/fluwx/ios/wechat_setup.rb:61:in `block in <main>'
        from /Users/alex/dev/garages/flutter/fluwx/ios/wechat_setup.rb:54:in `each'
        from /Users/alex/dev/garages/flutter/fluwx/ios/wechat_setup.rb:54:in `<main>'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/uri/rfc3986_parser.rb:16:in `split': undefined method `to_str' for nil:NilClass (NoMethodError)
        from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/uri/rfc3986_parser.rb:73:in `parse'
        from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/uri/common.rb:234:in `parse'
        from /Users/alex/dev/garages/flutter/fluwx/ios/wechat_setup.rb:61:in `block in <main>'
        from /Users/alex/dev/garages/flutter/fluwx/ios/wechat_setup.rb:54:in `each'
        from /Users/alex/dev/garages/flutter/fluwx/ios/wechat_setup.rb:54:in `<main>'
Downloading dependencies
Generating Pods project
Integrating client project
Pod installation complete! 
```

After

```console
Analyzing dependencies
[fluwx] 5.1.2
[fluwx] Using SDK with no_pay
Downloading dependencies
Generating Pods project
Integrating client project
Pod installation complete!
```