### PR TITLE
🐛 Only append app_id and universal_link for the command when exist

### DIFF
--- a/ios/fluwx.podspec
+++ b/ios/fluwx.podspec
@@ -76,7 +76,11 @@ if !universal_link.nil? && !universal_link.empty?
     Pod::UI.puts "[fluwx] universal_link: #{universal_link}"
 end
 
-system("ruby #{current_dir}/wechat_setup.rb #{ignore_security} -a #{app_id} -u #{universal_link} -p #{project_dir} -n Runner.xcodeproj")
+command = "ruby #{current_dir}/wechat_setup.rb #{ignore_security}"
+command += " -p #{project_dir} -n Runner.xcodeproj"
+command += " -a #{app_id}" unless app_id.nil? || app_id.empty?
+command += " -u #{universal_link}" unless universal_link.nil? || universal_link.empty?
+system(command)
 
 Pod::Spec.new do |s|
   s.name             = 'fluwx'


### PR DESCRIPTION
When no `app_id` was specified in the `pubspec.yaml`, the command will be `ruby path_to_dir/wechat_setup.rb -a  -u xxx -p xxx` which the `app_id` will be recognized as `-u`, then inserted to the `Info.plist`. The PR fixes the unexpected behavior.