### PR TITLE
🐛 Do not append empty associate domains

### DIFF
--- a/ios/wechat_setup.rb
+++ b/ios/wechat_setup.rb
@@ -56,7 +56,7 @@ project.targets.each do |target|
         app_id = options_dict[:app_id]
         universal_link = options_dict[:universal_link]
 
-        applinks = ''
+        applinks = nil
         if (!app_id.nil? && !app_id.empty? && !universal_link.nil? && !universal_link.empty?)
             begin
                 applinks = "applinks:#{URI.parse(universal_link).host}"
@@ -159,7 +159,7 @@ project.targets.each do |target|
                 result["com.apple.developer.associated-domains"] = domains
             end
             isApplinksExist = domains.include? applinks
-            if !isApplinksExist
+            if !isApplinksExist && !applinks.nil?
                 domains << applinks
                 File.write(codeSignEntitlementsFile, Plist::Emit.dump(result))
             end


### PR DESCRIPTION
The previous script will append an empty item of associate domains into `Runner.entitlement` if no config has been set in the `pubspec.yaml`.