### PR TITLE
修复 iOS FlutterSceneDelegate 下微信开放标签冷启动回调

### DIFF
--- a/packages/_shared/ios/Sources/FluwxPlugin.m
+++ b/packages/_shared/ios/Sources/FluwxPlugin.m
@@ -418,9 +418,7 @@ NSObject <FlutterPluginRegistrar> *_fluwxRegistrar;
 
 // Available on iOS 9.0 and later
 // See https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623112-application?language=objc
-- (BOOL)application:(UIApplication *)app
-            openURL:(NSURL *)url
-            options:(NSDictionary<NSString *, id> *)options {
+- (BOOL)handleOrCacheOpenURL:(NSURL *)url {
     // ↓ previous solution -- according to document, this may fail if the WXApi hasn't registered yet.
     // return [WXApi handleOpenURL:url delegate:self];
 
@@ -440,6 +438,31 @@ NSObject <FlutterPluginRegistrar> *_fluwxRegistrar;
         // simply return YES to indicate that we can handle open url request later
         return NO;
     }
+}
+
+- (BOOL)application:(UIApplication *)app
+            openURL:(NSURL *)url
+            options:(NSDictionary<NSString *, id> *)options {
+    return [self handleOrCacheOpenURL:url];
+}
+
+// Fix wx-open-launch-app cold starts when using FlutterSceneDelegate. Custom URL schemes are
+// delivered through UIScene connection options on cold start and openURLContexts while running.
+- (BOOL)scene:(UIScene *)scene openURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts API_AVAILABLE(ios(13.0)) {
+    BOOL handled = NO;
+    for (UIOpenURLContext *context in URLContexts) {
+        handled = [self handleOrCacheOpenURL:context.URL] || handled;
+    }
+    return handled;
+}
+
+- (BOOL)scene:(UIScene *)scene
+    willConnectToSession:(UISceneSession *)session
+                 options:(UISceneConnectionOptions *)connectionOptions API_AVAILABLE(ios(13.0)) {
+    if (connectionOptions == nil || connectionOptions.URLContexts.count == 0) {
+        return NO;
+    }
+    return [self scene:scene openURLContexts:connectionOptions.URLContexts];
 }
 
 - (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray *_Nonnull))restorationHandler{


### PR DESCRIPTION
## 问题说明

iOS App 使用 `FlutterSceneDelegate` 时，通过微信开放标签 `wx-open-launch-app` 冷启动 App，自定义微信 URL Scheme 会通过 `UISceneConnectionOptions.urlContexts` 传入。

fluwx 当前处理了 `UIApplicationDelegate.application:openURL:options:`，但没有处理 UIScene 对应的冷启动入口，导致：

- 微信可以成功冷启动 App；
- `registerApi()` 正常返回 `true`；
- Dart subscriber 无法收到 `WeChatLaunchFromWXRequest`；
- 无法获取开放标签传入的 `extMsg`。

## 修改内容

- 将现有 URL Scheme 处理和缓存逻辑抽取为 `handleOrCacheOpenURL:`；
- 新增 `scene:openURLContexts:`，处理 App 运行期间收到的自定义 URL Scheme；
- 新增 `scene:willConnectToSession:options:`，处理冷启动时 `connectionOptions.URLContexts` 中的 URL；
- 复用现有 `_cachedOpenUrlRequest` 和 `attemptToResumeMsgFromWx()` 流程；
- 不修改现有 Dart API 和 Android 行为。

## 测试结果

已在 iOS 真机 Profile 模式下测试：

1. 完全结束 App；
2. 通过微信开放标签冷启动；
3. `registerApi()` 返回 `true`；
4. Dart subscriber 收到 `WeChatLaunchFromWXRequest`；
5. 成功获取 `extMsg`；
6. App 成功跳转到指定业务页面。

## 关联问题

Fixes #769  
Related to #733  
Follow-up to #755