### PR TITLE
修复 Android Kotlin 构建配置

### DIFF
--- a/packages/_shared/android/build.gradle.kts
+++ b/packages/_shared/android/build.gradle.kts
@@ -84,13 +84,6 @@ android {
     }
 }
 
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
-    }
-}
-
-
 project.extensions.configure(org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension::class.java) {
     compilerOptions {
         jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17


### PR DESCRIPTION
# 修复 Android Kotlin Gradle 脚本编译错误

## 问题说明

在 Flutter 项目中通过 Git 依赖使用 fluwx 6.0.0 时，Android 构建失败：

```text
Unresolved reference: kotlin
Unresolved reference: compilerOptions
Unresolved reference: jvmTarget
```

错误位置：

```kotlin
kotlin {
    compilerOptions {
        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
    }
}
```

## 原因分析

当前构建脚本根据 Android Gradle Plugin 版本动态应用 Kotlin 插件：

```kotlin
if (agpMajor < 9) {
    apply(plugin = "org.jetbrains.kotlin.android")
}
```

由于 Kotlin 插件通过 `apply(plugin = ...)` 动态应用，Kotlin DSL 在脚本编译阶段无法生成并识别以下类型安全访问器：

```kotlin
kotlin {
    compilerOptions {
        // ...
    }
}
```

同时，构建脚本下方已经存在兼容动态插件加载方式的 JVM Target 配置：

```kotlin
project.extensions.configure(
    org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension::class.java
) {
    compilerOptions {
        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
    }
}
```

两段代码配置了相同的 `JVM_17`。前一段属于重复配置，并且会导致 Kotlin DSL 脚本编译失败。

## 修改内容

删除无法解析的重复配置：

```kotlin
kotlin {
    compilerOptions {
        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
    }
}
```

保留兼容动态插件加载方式的配置：

```kotlin
project.extensions.configure(
    org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension::class.java
) {
    compilerOptions {
        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
    }
}
```

本次修改不改变实际的 JVM Target，仍然使用 Java 17。

## 测试方式

在 Flutter 项目中通过 Git 依赖引用修改后的 fluwx，然后执行：

```bash
flutter pub get
flutter build apk --debug
```

## 测试结果

```text
✓ Built build/app/outputs/flutter-apk/app-debug.apk
```

Android Debug APK 构建成功。

## 兼容性说明

- 不修改 fluwx 的 Android 业务逻辑；
- 不修改现有 Dart API；
- 不修改 iOS 实现；
- JVM Target 仍为 `JVM_17`；
- 仅删除重复且无法解析的 Kotlin DSL 配置。